### PR TITLE
Add left and right brackets as PAGEUP and PAGEDOWN keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ Up - Scroll up
 
 Down - Scroll down
 
-Left - Last system (if it exists)
+PageUp or ] - Page up
+
+PageDown or [ - Page down
+
+Left - Previous system (if it exists)
 
 Right - Next system (if it exists)
 

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -61,7 +61,13 @@ void InputManager::processEvent(SDL_Event* event)
 			case SDLK_PAGEUP:
 				button = PAGEUP;
 				break;
+			case SDLK_RIGHTBRACKET:
+				button = PAGEUP;
+				break;
 			case SDLK_PAGEDOWN:
+				button = PAGEDOWN;
+				break;
+			case SDLK_LEFTBRACKET:
 				button = PAGEDOWN;
 				break;
 			case SDLK_RETURN:


### PR DESCRIPTION
Some devices, such as an IPAC are hard to program for PGUP and PGDOWN.
This makes it much easier and they are two keys that usually won't get
used for anything.
