### PR TITLE
Add display sleep for rpi

### DIFF
--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -17,6 +17,8 @@ namespace Renderer
 {
 	bool init(int w, int h);
 	void deinit();
+	void wake(int w, int h);
+	void sleep();
 
 	//just takes care of default font init/deinit right now
 	void onInit();

--- a/src/Renderer_init_sdlgl.cpp
+++ b/src/Renderer_init_sdlgl.cpp
@@ -107,7 +107,6 @@ namespace Renderer
 		//show mouse cursor
 		SDL_ShowCursor(initialCursorState);
 
-		SDL_Quit();
 	}
 
 	bool init(int w, int h)
@@ -132,6 +131,19 @@ namespace Renderer
 	}
 
 	void deinit()
+	{
+		onDeinit();
+
+		destroySurface();
+		SDL_Quit();
+	}
+
+	void wake(int w, int h)
+	{
+		init();
+	}
+
+	void sleep()
 	{
 		onDeinit();
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -31,6 +31,9 @@ void Settings::setDefaults()
 	mBoolMap["DONTSHOWEXIT"] = false;
 	mBoolMap["DEBUG"] = false;
 	mBoolMap["WINDOWED"] = false;
+#ifdef _RPI_
+	mBoolMap["PIHMDISLEEP"] = false;
+#endif
 
 	mIntMap["DIMTIME"] = 30*1000;
 

--- a/src/SystemData.cpp
+++ b/src/SystemData.cpp
@@ -4,6 +4,7 @@
 #include <boost/filesystem.hpp>
 #include <fstream>
 #include <stdlib.h>
+#include <SDL.h>
 #include <SDL_joystick.h>
 #include "Renderer.h"
 #include "AudioManager.h"
@@ -12,6 +13,8 @@
 #include "InputManager.h"
 #include <iostream>
 #include "Settings.h"
+
+extern int lastTime;
 
 std::vector<SystemData*> SystemData::sSystemVector;
 
@@ -98,6 +101,8 @@ void SystemData::launchGame(Window* window, GameData* game)
 	//update number of times the game has been launched and the time
 	game->setTimesPlayed(game->getTimesPlayed() + 1);
 	game->setLastPlayed(std::time(nullptr));
+
+	lastTime = SDL_GetTicks();
 }
 
 void SystemData::populateFolder(FolderData* folder)

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -73,6 +73,28 @@ void Window::deinit()
 	Renderer::deinit();
 }
 
+void Window::wake()
+{
+	mInputManager->init();
+	Renderer::wake(0, 0);
+
+	for(unsigned int i = 0; i < mGuiStack.size(); i++)
+	{
+		mGuiStack.at(i)->init();
+	}
+}
+
+void Window::sleep()
+{
+	for(unsigned int i = 0; i < mGuiStack.size(); i++)
+	{
+		mGuiStack.at(i)->deinit();
+	}
+
+	mInputManager->deinit();
+	Renderer::sleep();
+}
+
 void Window::input(InputConfig* config, Input input)
 {
 	if(config->isMappedTo("mastervolup", input))

--- a/src/Window.h
+++ b/src/Window.h
@@ -21,6 +21,8 @@ public:
 
 	void init();
 	void deinit();
+	void wake();
+	void sleep();
 
 	InputManager* getInputManager();
 


### PR DESCRIPTION
This adds wake/sleep methods to the Window and Renderer classes to support display sleep.  I have attempted to stub out the methods for the non-rpi sdl implementation, but have only tried on the rpi.
