### PR TITLE
Fix for Issue #147.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,6 +110,8 @@ bool verifyHomeFolderExists()
 //called on exit, assuming we get far enough to have the log initialized
 void onExit()
 {
+	Renderer::deinit();
+
 	Log::close();
 
 	#ifdef _RPI_


### PR DESCRIPTION
Issue #147.  Now call Renderer::deinit() in onExit() so the SDL window is closed if we exit uncleanly.
