### PR TITLE
Add Emulator Documentation in SYSTEMS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ All systems must be contained within the <systemList> tag.-->
 		<!-- A "pretty" name, displayed in the menus and such. This one is optional. -->
 		<fullname>Super Nintendo Entertainment System</fullname>
 
-		<!-- The path to start searching for ROMs in. '~' will be expanded to $HOME or %HOMEPATH%, depending on platform. 
+		<!-- The path to start searching for ROMs in. '~' will be expanded to $HOME or %HOMEPATH%, depending on platform.
 		All subdirectories (and non-recursive links) will be included. -->
 		<path>~/roms/snes</path>
 
@@ -180,6 +180,7 @@ The following "tags" are replaced by ES in launch commands:
 
 `%ROM_RAW%`	- Replaced with the unescaped, absolute path to the selected ROM.  If your emulator is picky about paths, you might want to use this instead of %ROM%, but enclosed in quotes.
 
+See [SYSTEMS.md](SYSTEMS.md) for some live examples in EmulationStation.
 
 gamelist.xml
 ============

--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -1,0 +1,183 @@
+# Systems
+
+This outlines how to add support for many different systems into EmulationStation through configuration of `es_systems.cfg`.
+
+## Nintendo Wii
+
+### [Dolphin](http://dolphin-emu.org/)
+In Options → Configure → Interface, disable *Confirm to Stop*.
+``` xml
+<system>
+  <name>wii</name>
+  <fullname>Nintendo Wii</fullname>
+  <path>/rom/path/here</path>
+  <extension>.elf .dol .gcm .iso .wbfs .ciso .gcz .wad</extension>
+  <command>dolphin-emu -b -e %ROM%</command>
+  <platform>wii</platform>
+  <theme>wii</theme>
+</system>
+```
+
+
+## [Nintendo GameCube](https://en.wikipedia.org/wiki/GameCube)
+
+### [Dolphin](http://dolphin-emu.org/)
+In Options → Configure → Interface, disable *Confirm to Stop*.
+``` xml
+<system>
+  <name>gc</name>
+  <fullname>Nintendo GameCube</fullname>
+  <path>/rom/path/here</path>
+  <extension>.elf .dol .gcm .iso .wbfs .ciso .gcz .wad</extension>
+  <command>dolphin-emu -b -e %ROM%</command>
+  <platform>gc</platform>
+  <theme>gc</theme>
+</system>
+```
+
+
+## Nintendo 64
+
+### [RetroArch](http://libretro.com)
+Requires a [Nintendo N64 Core](http://wiki.libretro.com/index.php?title=Nintendo_N64_Core_Compatibility), like [`libretro-mupen64plus`](http://wiki.libretro.com/index.php?title=Mupen64Plus).
+``` xml
+<system>
+  <name>n64</name>
+  <fullname>Nintendo 64</fullname>
+  <path>/path/to/roms</path>
+  <extension>.z64 .zip .n64</extension>
+  <command>retroarch --fullscreen -L /usr/lib/libretro/mupen64plus_libretro.so %ROM%</command>
+  <platform>n64</platform>
+  <theme>n64</theme>
+</system>
+```
+
+### [Mupen64Plus](https://code.google.com/p/mupen64plus/)
+``` xml
+<system>
+  <name>n64</name>
+  <fullname>Nintendo 64</fullname>
+  <path>/path/to/roms</path>
+  <extension>.z64 .zip .n64</extension>
+  <command>mupen64plus --nogui --noask --noosd --fullscreen %ROM%</command>
+  <platform>n64</platform>
+  <theme>n64</theme>
+</system>
+```
+
+
+## Nintendo Entertainment System
+
+### [RetroArch](http://libretro.com)
+Requires a [Nintendo NES Core](http://wiki.libretro.com/index.php?title=Nintendo_NES_Core_Compatibility), like [`libretro-fceumm`](http://wiki.libretro.com/index.php?title=FCEUmm).
+``` xml
+<system>
+  <name>nes</name>
+  <fullname>Nintendo Entertainment System</fullname>
+  <path>/path/to/roms</path>
+  <extension>.nes .NES .zip</extension>
+  <command>retroarch --fullscreen -L /usr/lib/libretro/fceumm_libretro.so %ROM%</command>
+  <platform>nes</platform>
+  <theme>nes</theme>
+</system>
+```
+
+### [Mednafen](http://mednafen.sourceforge.net/)
+``` xml
+<system>
+  <name>nes</name>
+  <fullname>Nintendo Entertainment System</fullname>
+  <path>/path/to/roms</path>
+  <extension>.nes .NES .zip</extension>
+  <command>mednafen -video.fs 1 %ROM%</command>
+  <platform>nes</platform>
+  <theme>nes</theme>
+</system>
+```
+
+
+## Super Nintendo Entertainment System
+
+### [ZSNES](http://zsnes.com/)
+``` xml
+<system>
+  <name>snes</name>
+  <fullname>Super Nintendo Entertainment System</fullname>
+  <path>/path/to/roms</path>
+  <extension>.smc .sfc .swc .fig .mgd .mgh .ufo .bin .gd3 .gd7 .usa .eur .jap .aus .st .bs .dx2 .048 .058 .078 .1 .a .gz .zip .jma</extension>
+  <command>zsnes -m %ROM%</command>
+  <platform>snes</platform>
+  <theme>snes</theme>
+</system>
+```
+
+### [RetroArch](http://libretro.com)
+Requires a [Nintendo SNES Core](http://wiki.libretro.com/index.php?title=Nintendo_SNES_Core_Compatibility), like [`libretro-snes9x-next`](http://wiki.libretro.com/index.php?title=SNES9x_Next).
+``` xml
+<system>
+  <name>snes</name>
+  <fullname>Super Nintendo Entertainment System</fullname>
+  <path>/path/to/roms</path>
+  <extension>.smc .sfc .fig .bin .zip</extension>
+  <command>retroarch --fullscreen -L /usr/lib/libretro/snes9x_next_libretro.so %ROM%</command>
+  <platform>snes</platform>
+  <theme>snes</theme>
+</system>
+```
+
+## Atari 2600
+
+### [Stella](http://stella.sourceforge.net/)
+``` xml
+<system>
+  <name>atari2600</name>
+  <fullname>Atari 2600</fullname>
+  <path>/path/to/roms</path>
+  <extension>.bin .zip</extension>
+  <command>stella %ROM%</command>
+  <platform>atari2600</platform>
+  <theme>atari2600</theme>
+</system>
+```
+
+## Nintendo GameBoy Advance
+
+### [Mednafen](http://mednafen.sourceforge.net/)
+``` xml
+<system>
+  <name>gba</name>
+  <fullname>Nintendo GameBoy Advance</fullname>
+  <path>/path/to/roms</path>
+  <extension>.gba .zip</extension>
+  <command>mednafen -video.fs 1 %ROM%</command>
+  <platform>gba</platform>
+  <theme>gba</theme>
+</system>
+```
+
+### [VisualBoyAdvance](http://sourceforge.net/projects/vba/)
+``` xml
+<system>
+  <name>gba</name>
+  <fullname>Nintendo GameBoy Advance</fullname>
+  <path>/path/to/roms</path>
+  <extension>.gba .zip</extension>
+  <command>VisualBoyAdvance -F %ROM%</command>
+  <platform>gba</platform>
+  <theme>gba</theme>
+</system>
+```
+
+### [RetroArch](http://libretro.com)
+Requires a [Nintendo GameBoy Advance Core](http://wiki.libretro.com/index.php?title=Nintendo_Game_Boy_Advance_Core_Compatibility), like [`libretro-vba-next`](http://wiki.libretro.com/index.php?title=VBA_Next).
+``` xml
+<system>
+  <name>gba</name>
+  <fullname>Nintendo GameBoy Advance</fullname>
+  <path>/path/to/roms</path>
+  <extension>.gba .zip</extension>
+  <command>retroarch --fullscreen -L /usr/lib/libretro/vba_next_libretro.so %ROM%</command>
+  <platform>gba</platform>
+  <theme>gba</theme>
+</system>
+```


### PR DESCRIPTION
This adds a [SYSTEMS.md](https://github.com/RobLoach/EmulationStation/blob/systems/SYSTEMS.md) which outlines how to add support for many different systems into **EmulationStation**. The goal is to document usage of a number of platforms, along with as many emulators as possible which support it. This allows users to easily copy and paste the XML into their `es_systems.cfg` without having to worry too much.
- [Preview the current version](https://github.com/RobLoach/EmulationStation/blob/systems/SYSTEMS.md#readme) too see what it would be like once merged.
- More emulators and platforms are to be added - Git allows easy collaboration on this
- @ProfessorKaos64 has [a great `es_systems.cfg`](https://github.com/ProfessorKaos64/RetroRig-ES/blob/master/es-cfgs/es_systems.cfg) set up that we could merge in
