### PR TITLE
Gamesdb list-based scraper

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -30,6 +30,7 @@ set(ES_HEADERS
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/GamesDBScraper.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/GamesDBListScraper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/TheArchiveScraper.h
 
     # Views
@@ -76,6 +77,7 @@ set(ES_SOURCES
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/GamesDBScraper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/GamesDBListScraper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/TheArchiveScraper.cpp
 
     # Views

--- a/es-app/src/scrapers/GamesDBListScraper.cpp
+++ b/es-app/src/scrapers/GamesDBListScraper.cpp
@@ -125,12 +125,16 @@ void TheGamesDBListRequest::process(const std::unique_ptr<HttpReq>& req, std::ve
 		ScraperSearchResult result;
 		std::string gameId = game.child("id").text().get();
 		std::string gameUrl = "thegamesdb.net/api/GetGame.php?id=" + gameId;
+
+		// Perform GetGame request for each game id in GetGamesList result
 		HttpReq gameReq(gameUrl);
 
+		// Wait for request to finish (make it synchronous)
 		while (gameReq.status() == HttpReq::REQ_IN_PROGRESS);
 
 		if (gameReq.status() == HttpReq::REQ_SUCCESS)
 		{
+			// Process response into game result, results are unique based on id
 			pugi::xml_document doc;
 			pugi::xml_parse_result parseResult = doc.load(gameReq.getContent().c_str());
 			if(!parseResult)

--- a/es-app/src/scrapers/GamesDBListScraper.cpp
+++ b/es-app/src/scrapers/GamesDBListScraper.cpp
@@ -1,0 +1,185 @@
+#include "scrapers/GamesDBListScraper.h"
+#include "Log.h"
+#include "pugixml/pugixml.hpp"
+#include "MetaData.h"
+#include "Settings.h"
+#include "Util.h"
+#include <boost/assign.hpp>
+
+using namespace PlatformIds;
+const std::map<PlatformId, const char*> gamesdb_platformid_map = boost::assign::map_list_of
+	(THREEDO, "3DO")
+	(AMIGA, "Amiga")
+	(AMSTRAD_CPC, "Amstrad CPC")
+	// missing apple2
+	(ARCADE, "Arcade")
+	// missing atari 800
+	(ATARI_2600, "Atari 2600")
+	(ATARI_5200, "Atari 5200")
+	(ATARI_7800, "Atari 7800")
+	(ATARI_JAGUAR, "Atari Jaguar")
+	(ATARI_JAGUAR_CD, "Atari Jaguar CD")
+	(ATARI_LYNX, "Atari Lynx")
+	// missing atari ST/STE/Falcon
+	(ATARI_XE, "Atari XE")
+	(COLECOVISION, "Colecovision")
+	(COMMODORE_64, "Commodore 64")
+	(INTELLIVISION, "Intellivision")
+	(MAC_OS, "Mac OS")
+	(XBOX, "Microsoft Xbox")
+	(XBOX_360, "Microsoft Xbox 360")
+	(NEOGEO, "NeoGeo")
+	(NEOGEO_POCKET, "Neo Geo Pocket")
+	(NEOGEO_POCKET_COLOR, "Neo Geo Pocket Color")
+	(NINTENDO_3DS, "Nintendo 3DS")
+	(NINTENDO_64, "Nintendo 64")
+	(NINTENDO_DS, "Nintendo DS")
+	(NINTENDO_ENTERTAINMENT_SYSTEM, "Nintendo Entertainment System (NES)")
+	(GAME_BOY, "Nintendo Game Boy")
+	(GAME_BOY_ADVANCE, "Nintendo Game Boy Advance")
+	(GAME_BOY_COLOR, "Nintendo Game Boy Color")
+	(NINTENDO_GAMECUBE, "Nintendo GameCube")
+	(NINTENDO_WII, "Nintendo Wii")
+	(NINTENDO_WII_U, "Nintendo Wii U")
+	(PC, "PC")
+	(SEGA_32X, "Sega 32X")
+	(SEGA_CD, "Sega CD")
+	(SEGA_DREAMCAST, "Sega Dreamcast")
+	(SEGA_GAME_GEAR, "Sega Game Gear")
+	(SEGA_GENESIS, "Sega Genesis")
+	(SEGA_MASTER_SYSTEM, "Sega Master System")
+	(SEGA_MEGA_DRIVE, "Sega Mega Drive")
+	(SEGA_SATURN, "Sega Saturn")
+	(PLAYSTATION, "Sony Playstation")
+	(PLAYSTATION_2, "Sony Playstation 2")
+	(PLAYSTATION_3, "Sony Playstation 3")
+	(PLAYSTATION_4, "Sony Playstation 4")
+	(PLAYSTATION_VITA, "Sony Playstation Vita")
+	(PLAYSTATION_PORTABLE, "Sony PSP")
+	(SUPER_NINTENDO, "Super Nintendo (SNES)")
+	(TURBOGRAFX_16, "TurboGrafx 16")
+	(WONDERSWAN, "WonderSwan")
+	(WONDERSWAN_COLOR, "WonderSwan Color")
+	(ZX_SPECTRUM, "Sinclair ZX Spectrum");
+
+
+void thegamesdblist_generate_scraper_requests(const ScraperSearchParams& params, std::queue< std::unique_ptr<ScraperRequest> >& requests,
+	std::vector<ScraperSearchResult>& results)
+{
+	std::string path = "thegamesdb.net/api/GetGamesList.php?";
+
+	std::string cleanName = params.nameOverride;
+	if(cleanName.empty())
+		cleanName = params.game->getCleanName();
+
+	path += "name=" + HttpReq::urlEncode(cleanName);
+
+	if(params.system->getPlatformIds().empty())
+	{
+		// no platform specified, we're done
+		requests.push(std::unique_ptr<ScraperRequest>(new TheGamesDBListRequest(results, path)));
+	}else{
+		// go through the list, we need to split this into multiple requests
+		// because TheGamesDB API either sucks or I don't know how to use it properly...
+		std::string urlBase = path;
+		auto& platforms = params.system->getPlatformIds();
+		for(auto platformIt = platforms.begin(); platformIt != platforms.end(); platformIt++)
+		{
+			path = urlBase;
+			auto mapIt = gamesdb_platformid_map.find(*platformIt);
+			if(mapIt != gamesdb_platformid_map.end())
+			{
+				path += "&platform=";
+				path += HttpReq::urlEncode(mapIt->second);
+			}else{
+				LOG(LogWarning) << "TheGamesDBList scraper warning - no support for platform " << getPlatformName(*platformIt);
+			}
+
+			requests.push(std::unique_ptr<ScraperRequest>(new TheGamesDBListRequest(results, path)));
+		}
+	}
+}
+
+void TheGamesDBListRequest::process(const std::unique_ptr<HttpReq>& req, std::vector<ScraperSearchResult>& results)
+{
+	assert(req->status() == HttpReq::REQ_SUCCESS);
+
+	pugi::xml_document listDoc;
+	pugi::xml_parse_result listParseResult = listDoc.load(req->getContent().c_str());
+
+	if(!listParseResult)
+	{
+		std::stringstream ss;
+		ss << "GamesDBListRequest - Error parsing GamesList XML. \n\t" << listParseResult.description() << "";
+		std::string err = ss.str();
+		setError(err);
+		LOG(LogError) << err;
+		return;
+	}
+
+	pugi::xml_node listData = listDoc.child("Data");
+	pugi::xml_node game = listData.child("Game");
+
+	while(game && results.size() < MAX_SCRAPER_RESULTS)
+	{
+		ScraperSearchResult result;
+		std::string gameId = game.child("id").text().get();
+		std::string gameUrl = "thegamesdb.net/api/GetGame.php?id=" + gameId;
+		HttpReq gameReq(gameUrl);
+
+		while (gameReq.status() == HttpReq::REQ_IN_PROGRESS);
+
+		if (gameReq.status() == HttpReq::REQ_SUCCESS)
+		{
+			pugi::xml_document doc;
+			pugi::xml_parse_result parseResult = doc.load(gameReq.getContent().c_str());
+			if(!parseResult)
+			{
+				std::stringstream ss;
+				ss << "GamesDBList HttpReq - Error parsing Game XML. \n\t" << parseResult.description() << "";
+				std::string err = ss.str();
+				setError(err);
+				LOG(LogError) << err;
+			}
+			else
+			{
+				pugi::xml_node data = doc.child("Data");
+				std::string baseImageUrl = data.child("baseImgUrl").text().get();
+				pugi::xml_node game = data.child("Game");
+
+				result.mdl.set("name", game.child("GameTitle").text().get());
+				result.mdl.set("desc", game.child("Overview").text().get());
+
+				boost::posix_time::ptime rd = string_to_ptime(game.child("ReleaseDate").text().get(), "%m/%d/%Y");
+				result.mdl.setTime("releasedate", rd);
+
+				result.mdl.set("developer", game.child("Developer").text().get());
+				result.mdl.set("publisher", game.child("Publisher").text().get());
+				result.mdl.set("genre", game.child("Genres").first_child().text().get());
+				result.mdl.set("players", game.child("Players").text().get());
+
+				if(Settings::getInstance()->getBool("ScrapeRatings") && game.child("Rating"))
+				{
+					float ratingVal = (game.child("Rating").text().as_int() / 10.0f);
+					std::stringstream ss;
+					ss << ratingVal;
+					result.mdl.set("rating", ss.str());
+				}
+
+				pugi::xml_node images = game.child("Images");
+
+				if(images)
+				{
+					pugi::xml_node art = images.find_child_by_attribute("boxart", "side", "front");
+					if(art)
+					{
+						result.thumbnailUrl = baseImageUrl + art.attribute("thumb").as_string();
+						result.imageUrl = baseImageUrl + art.text().get();
+					}
+				}
+				results.push_back(result);
+			}
+		}
+		game = game.next_sibling("Game");
+	}
+}

--- a/es-app/src/scrapers/GamesDBListScraper.h
+++ b/es-app/src/scrapers/GamesDBListScraper.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "scrapers/Scraper.h"
+
+void thegamesdblist_generate_scraper_requests(const ScraperSearchParams& params, std::queue< std::unique_ptr<ScraperRequest> >& requests,
+	std::vector<ScraperSearchResult>& results);
+
+class TheGamesDBListRequest : public ScraperHttpRequest
+{
+public:
+	TheGamesDBListRequest(std::vector<ScraperSearchResult>& resultsWrite, const std::string& url) : ScraperHttpRequest(resultsWrite, url) {}
+protected:
+	void process(const std::unique_ptr<HttpReq>& req, std::vector<ScraperSearchResult>& results) override;
+};

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -6,10 +6,12 @@
 #include <boost/assign.hpp>
 
 #include "GamesDBScraper.h"
+#include "GamesDBListScraper.h"
 #include "TheArchiveScraper.h"
 
 const std::map<std::string, generate_scraper_requests_func> scraper_request_funcs = boost::assign::map_list_of
 	("TheGamesDB", &thegamesdb_generate_scraper_requests)
+	("TheGamesDBList", &thegamesdblist_generate_scraper_requests)
 	("TheArchive", &thearchive_generate_scraper_requests);
 
 std::unique_ptr<ScraperSearchHandle> startScraperSearch(const ScraperSearchParams& params)


### PR DESCRIPTION
The GamesDB unfortunately appears to use the default fulltext search settings for MySQL.
This means that words in titles less than 4 characters in length are not indexed. For
example, if you attempt a GetGame search for 'Dig Dug', it will not yield a result. However,
searching on the gamesdb site in a browser shows the game is in the database.

The emulation station code
(https://github.com/Aloshi/EmulationStation/blob/master/es-app/src/scrapers/GamesDBScraper.cpp#L66),
constructs the following gamesdb query to scrape for 'Dig Dug' on the Atari 2600:

http://thegamesdb.net/api/GetGame.php?platform=Atari%202600&name=Dig%20Dug

Looking at the source code for the gamesdb GetGame endpoint
(https://github.com/TheGamesDB/TheGamesDB/blob/master/api/GetGame.php#L245), it executes the
following mysql query to lookup the game title:

```
SELECT id FROM games WHERE MATCH(GameTitle) AGAINST ('Dig Dug') ...
```

For many games, this will succeed. However, because the full-text index includes neither
'dig' nor 'dug' because of the indexing configuration, it does not return the expected result. By
performing a similar search using the gamesdb GetGamesList endpoint:

http://thegamesdb.net/api/GetGamesList.php?name=Dig%20Dug&platform=Atari%202600

We see the result we expected. You can see from the code that the GetGamesList query tries
to find the title using the same fulltext clause, but also includes similar sounding titles.
This difference allows you to find the title.

There are really two solutions that can improve user experience: improving the gamesdb full-text index to include a larger set of titles, and providing an emulation station scraper that doesn't rely solely on the full-text search endpoint (this pull request).
## Work-around using GetGamesList

In lieu of fixing the indexing at GamesDB, we can work around the limitation by using GetGamesList
to lookup the games by name, and then lookup the game using GetGame by id.

http://thegamesdb.net/api/GetGamesList.php?name=Dig%20Dug&platform=Atari%202600

Yields:

```
<Data>
<Game>
<id>207</id>
<GameTitle>Dig Dug</GameTitle>
<ReleaseDate>01/01/1982</ReleaseDate>
<Platform>Atari 2600</Platform>
</Game>
</Data>
```

Then, using the id from these results we can get the detailed information using the GetGame endpoint:

http://thegamesdb.net/api/GetGame.php?platform=Atari%202600&id=207

Which yields:

```
<Data>
<baseImgUrl>http://thegamesdb.net/banners/</baseImgUrl>
<Game>
<id>207</id>
<GameTitle>Dig Dug</GameTitle>
<PlatformId>22</PlatformId>
<Platform>Atari 2600</Platform>
<ReleaseDate>01/01/1982</ReleaseDate>
<Overview>
The objective of Dig Dug is to eliminate underground-dwelling monsters. This can be done by inflating them until they pop or by dropping rocks on them. There are two kinds of enemies in the game: Pookas, round red monsters (said to be modeled after tomatoes) who wear yellow goggles, and Fygars, green dragons who can breathe fire. The player's character is Dig Dug, dressed in white and blue, and able to dig tunnels. Dig Dug is killed if he is caught by either Pooka or Fygar, burned by a Fygar's fire, or crushed by a rock.
</Overview>
<ESRB>E - Everyone</ESRB>
<Genres>
<genre>Puzzle</genre>
</Genres>
<Publisher>Namco</Publisher>
<Developer>Namco</Developer>
<Rating>6</Rating>
<Images>
<fanart>
<original width="1920" height="1080">fanart/original/207-1.jpg</original>
<thumb>fanart/thumb/207-1.jpg</thumb>
</fanart>
<boxart side="back" width="1527" height="2100" thumb="boxart/thumb/original/back/207-1.jpg">boxart/original/back/207-1.jpg</boxart>
<boxart side="front" width="1530" height="2100" thumb="boxart/thumb/original/front/207-1.jpg">boxart/original/front/207-1.jpg</boxart>
<banner width="760" height="140">graphical/207-g.jpg</banner>
<clearlogo width="400" height="118">clearlogo/207.png</clearlogo>
</Images>
</Game>
</Data>
```

By using the GetGamesList endpoint, which includes soundex matches, it finds titles not
indexed due to dropping words less than 4 letters long. Additionally, it will find titles
that are misspelled or abbreviated as long as the form sounds similar to the full title.
By implementing a scraper using this technique, users can find titles
currently inaccessible using the existing gamesdb scraper.
