### PR TITLE
Add/remove a game from favorite feature.

### DIFF
--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -18,7 +18,8 @@ MetaDataDecl gameDecls[] = {
 	{"genre",		MD_STRING,				"unknown",			false,		"genre",				"enter game genre"},
 	{"players",		MD_INT,					"1",				false,		"players",				"enter number of players"},
 	{"playcount",	MD_INT,					"0",				true,		"play count",			"enter number of times played"},
-	{"lastplayed",	MD_TIME,				"0", 				true,		"last played",			"enter last played date"}
+	{"lastplayed",	MD_TIME,				"0", 				true,		"last played",			"enter last played date"},
+	{"favorite",	MD_INT,					"0",				true,		"favorite",				"favorite this game?"},
 };
 const std::vector<MetaDataDecl> gameMDD(gameDecls, gameDecls + sizeof(gameDecls) / sizeof(gameDecls[0]));
 

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -51,6 +51,14 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::openMetaDataEd, this));
 	mMenu.addRow(row);
 
+	// add/remove from favorite entry.
+	row.elements.clear();
+	FileData* file = getGamelist()->getCursor();
+	bool isFavorite = file->metadata.get("favorite") == "1";
+	row.addElement(std::make_shared<TextComponent>(mWindow, isFavorite ? "REMOVE FROM FAVORITE" : "ADD TO FAVORITE", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+	row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::changeFavoriteState, this));
+	mMenu.addRow(row);
+
 	// center the menu
 	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 	mMenu.setPosition((mSize.x() - mMenu.getSize().x()) / 2, (mSize.y() - mMenu.getSize().y()) / 2);
@@ -64,6 +72,28 @@ GuiGamelistOptions::~GuiGamelistOptions()
 
 	// notify that the root folder was sorted
 	getGamelist()->onFileChanged(root, FILE_SORTED);
+}
+
+// Switches the "favorite" state of the currently selected game.
+void GuiGamelistOptions::changeFavoriteState()
+{
+	// currently selected game
+	FileData* file = getGamelist()->getCursor();
+	// switch the value.
+	if (file != NULL)
+	{
+		if (file->metadata.get("favorite") == "0")
+		{
+			file->metadata.set("favorite", "1");
+		}
+		else
+		{
+			file->metadata.set("favorite", "0");
+		}
+	}
+
+	// closes the dialog
+	delete this;
 }
 
 void GuiGamelistOptions::openMetaDataEd()

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -16,6 +16,7 @@ public:
 
 private:
 	void openMetaDataEd();
+	void changeFavoriteState();
 	void jumpToLetter();
 	
 	MenuComponent mMenu;

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -41,6 +41,18 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 
 	mHeaderText.setText(files.at(0)->getSystem()->getFullName());
 
+	// The TextListComponent would be able to insert at a specific position,
+	// but the cost of this operation could be seriously huge.
+	// This naive implemention of doing a first pass in the list is used instead.
+	for(auto it = files.begin(); it != files.end(); it++)
+	{
+		if ((*it)->metadata.get("favorite") == "1")
+		{
+			mList.add("* " + (*it)->getName(), *it, ((*it)->getType() == FOLDER)); // FIXME Folder as favorite ?
+		}
+	}
+
+	// full list of games with repeated favorites
 	for(auto it = files.begin(); it != files.end(); it++)
 	{
 		mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));


### PR DESCRIPTION
When a game is played for a few days/weeks/..., it's nice to have it at the top of the games list in the system.

The rating/last played sort allow it indirectly but it's not a perfect solution for the use-case. Another flaw of 
these sorts is that the games with the information (rating / last played) will be correctly ordered at the top but the others will have an undefined order.

This PR adds an entry in the OPTIONS menu, with the entry "add to favorite" or "remove from favorite" (depending on the current state of the game) to add/remove the currently selected game to favorite.
It saves the information into the `gamelist.xml` as an `MD_INT`, declared as a statistic info to not appear in GuiMetaDataEd.
The favorite games appear at the start of the games of list, preprended by a "*", but reappear in the main list. Example:
```
* Super Mario Bros 3
Alien
Super Ghouls'n'Ghosts
Super Mario Bros 3
```

The * is a simple ascii char and a good thing would be to use an utf8 start when ES will be ported to utf8.