### PR TITLE
Rom deletion halts ES due to double FileData removal

### DIFF
--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -75,10 +75,7 @@ void GuiGamelistOptions::openMetaDataEd()
 	p.system = file->getSystem();
 	mWindow->pushGui(new GuiMetaDataEd(mWindow, &file->metadata, file->metadata.getMDD(), p, file->getPath().filename().string(), 
 		std::bind(&IGameListView::onFileChanged, getGamelist(), file, FILE_METADATA_CHANGED), [this, file] { 
-			boost::filesystem::remove(file->getPath()); //actually delete the file on the filesystem
-			file->getParent()->removeChild(file); //unlink it so list repopulations triggered from onFileChanged won't see it
-			getGamelist()->onFileChanged(file, FILE_REMOVED); //tell the view
-			delete file; //free it
+			getGamelist()->remove(file);
 	}));
 }
 

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -86,6 +86,28 @@ void BasicGameListView::launch(FileData* game)
 	ViewController::get()->launch(game);
 }
 
+void BasicGameListView::remove(FileData *game)
+{
+	boost::filesystem::remove(game->getPath());  // actually delete the file on the filesystem
+	if (getCursor() == game)                     // Select next element in list, or prev if none
+	{
+		std::vector<FileData*> siblings = game->getParent()->getChildren();
+		auto gameIter = std::find(siblings.begin(), siblings.end(), game);
+		auto gamePos = std::distance(siblings.begin(), gameIter);
+		if (gameIter != siblings.end())
+		{
+			if ((gamePos + 1) < siblings.size())
+			{
+				setCursor(siblings.at(gamePos + 1));
+			} else if ((gamePos - 1) > 0) {
+				setCursor(siblings.at(gamePos - 1));
+			}
+		}
+	}
+	delete game;                                 // remove before repopulating (removes from parent)
+	onFileChanged(game, FILE_REMOVED);           // update the view, with game removed
+}
+
 std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts;

--- a/es-app/src/views/gamelist/BasicGameListView.h
+++ b/es-app/src/views/gamelist/BasicGameListView.h
@@ -23,6 +23,7 @@ public:
 protected:
 	virtual void populateList(const std::vector<FileData*>& files) override;
 	virtual void launch(FileData* game) override;
+	virtual void remove(FileData* game) override;
 
 	TextListComponent<FileData*> mList;
 };

--- a/es-app/src/views/gamelist/IGameListView.h
+++ b/es-app/src/views/gamelist/IGameListView.h
@@ -32,6 +32,7 @@ public:
 	virtual void setCursor(FileData*) = 0;
 
 	virtual bool input(InputConfig* config, Input input) override;
+	virtual void remove(FileData* game) = 0;
 
 	virtual const char* getName() const = 0;
 


### PR DESCRIPTION
When deleting a rom using the metadata screen, emulation station halts. The following assertion is the cause:

https://github.com/batkinson/EmulationStation/blob/master/es-app/src/FileData.cpp#L124

This occurs because of the deletion code:

https://github.com/batkinson/EmulationStation/blob/master/es-app/src/guis/GuiGamelistOptions.cpp#L78-L81

On line 79, the `FileData` object is removed using the parent's removeChild() method. Then on line 81 the `FileData` object is deleted, which attempts to again remove it from its parent in the destructor:

https://github.com/batkinson/EmulationStation/blob/master/es-app/src/FileData.cpp#L57
