### PR TITLE
Add a setting to allow for joystick input to work while not in focus.

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -1,5 +1,6 @@
 #include "InputManager.h"
 #include "InputConfig.h"
+#include "Settings.h"
 #include "Window.h"
 #include "Log.h"
 #include "pugixml/pugixml.hpp"
@@ -45,6 +46,9 @@ void InputManager::init()
 	if(initialized())
 		deinit();
 
+	if (Settings::getInstance()->getBool("BackgroundJoystickInput")){
+		SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+	}
 	SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 	SDL_JoystickEventState(SDL_ENABLE);
 

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -39,6 +39,7 @@ void Settings::setDefaults()
 	mBoolMap.clear();
 	mIntMap.clear();
 
+	mBoolMap["BackgroundJoystickInput"] = false;
 	mBoolMap["ParseGamelistOnly"] = false;
 	mBoolMap["DrawFramerate"] = false;
 	mBoolMap["ShowExit"] = true;


### PR DESCRIPTION
When launching EmulationStation as an X session without a window manager it doesn't receive joystick input because it thinks it's out of focus. This setting fixes that use case.

An example of this can be reproduced by creating a file `emulationstation.desktop` inside `/usr/share/xsessions` and then loging in with that session.

```
[Desktop Entry]
Type=Application
Exec=emulationstation
Name=Emulation Station
```