### PR TITLE
Fixes two memory leaks, which caused the scraper to crash after a while....

### DIFF
--- a/es-core/src/AsyncHandle.h
+++ b/es-core/src/AsyncHandle.h
@@ -12,6 +12,7 @@ class AsyncHandle
 {
 public:
 	AsyncHandle() : mStatus(ASYNC_IN_PROGRESS) {};
+	virtual ~AsyncHandle() {};
 
 	virtual void update() = 0;
 

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -14,6 +14,15 @@ NinePatchComponent::NinePatchComponent(Window* window, const std::string& path, 
 		buildVertices();
 }
 
+NinePatchComponent::~NinePatchComponent()
+{
+	if (mVertices != NULL)
+		delete[] mVertices;
+
+	if (mColors != NULL)
+		delete[] mColors;
+}
+
 void NinePatchComponent::updateColors()
 {
 	Renderer::buildGLColorArray(mColors, mEdgeColor, 6 * 9);

--- a/es-core/src/components/NinePatchComponent.h
+++ b/es-core/src/components/NinePatchComponent.h
@@ -18,6 +18,7 @@ class NinePatchComponent : public GuiComponent
 {
 public:
 	NinePatchComponent(Window* window, const std::string& path = "", unsigned int edgeColor = 0xFFFFFFFF, unsigned int centerColor = 0xFFFFFFFF);
+	virtual ~NinePatchComponent();
 
 	void render(const Eigen::Affine3f& parentTrans) override;
 


### PR DESCRIPTION
... I believe this fixes #180.

Fixes #352 (duplicate).
Fixes #362 (duplicate).

The destructor for AsyncHandle needs to be virtual as its subclasses are
allocated dynamically. I believe this caused the ImageDownloadHandle and its
related resources (such as the HttpReq and its contents) not to be freed
correctly.