### PR TITLE
Added ability to specify system options which can be set per-game.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ The following "tags" are replaced by ES in launch commands:
 
 See [SYSTEMS.md](SYSTEMS.md) for some live examples in EmulationStation.
 
+Additionally, you can specify options which can be set per-game - see [SYSTEMOPTIONS.md](SYSTEMOPTIONS.md).
+
 gamelist.xml
 ============
 

--- a/SYSTEMOPTIONS.md
+++ b/SYSTEMOPTIONS.md
@@ -1,0 +1,124 @@
+# System Options
+
+Each system specified in es_systems.cfg can have additional settings which are settable per-game.
+
+Here is an example providing additional options for each ZX Spectrum game, which changes which ZX Spectrum model the emulator (in this case FUSE) emulates:
+
+```xml
+    <system>
+
+        <name>zxspectrum</name>
+        <fullname>ZX Spectrum</fullname>
+        <path>~/roms/zxspectrum</path>
+        <extension>.tzx</extension>
+        <command>fuse %OPTIONS% %ROM%</command>
+        <platform>zxspectrum</platform>
+        <theme>zxspectrum</theme>
+
+        <option>
+            <id>machine</id>
+            <replace>%OPTIONS%</replace>
+            <desc>Spectrum model</desc>
+            <default>48</default>
+            <value>
+                <id>16</id>
+                <desc>ZX Spectrum 16K</desc>
+                <code>--machine 16</code>
+            </value>
+            <value>
+                <id>48</id>
+                <desc>ZX Spectrum 48K</desc>
+                <code>--machine 48</code>
+            </value>
+            <value>
+                <id>48_ntsc</id>
+                <desc>ZX Spectrum 48K (NTSC)</desc>
+                <code>--machine 48_ntsc</code>
+            </value>
+            <value>
+                <id>128</id>
+                <desc>ZX Spectrum 128K</desc>
+                <code>--machine 128</code>
+            </value>
+            <value>
+                <id>plus2</id>
+                <desc>ZX Spectrum +2</desc>
+                <code>--machine plus2</code>
+            </value>
+            <value>
+                <id>plus2a</id>
+                <desc>ZX Spectrum +2A</desc>
+                <code>--machine plus2a</code>
+            </value>
+            <value>
+                <id>plus3</id>
+                <desc>ZX Spectrum +3</desc>
+                <code>--machine plus3</code>
+            </value>
+            <value>
+                <id>plus3e</id>
+                <desc>ZX Spectrum +3E</desc>
+                <code>--machine plus3</code>
+            </value>
+            <value>
+                <id>se</id>
+                <desc>ZX Spectrum SE</desc>
+                <code>--machine se</code>
+            </value>
+            <value>
+                <id>pentagon</id>
+                <desc>Pentagon</desc>
+                <code>--machine pentagon</code>
+            </value>
+            <value>
+                <id>pentagon512</id>
+                <desc>Pentagon "512"</desc>
+                <code>--machine pentagon512</code>
+            </value>
+            <value>
+                <id>pentagon1024</id>
+                <desc>Pentagon 1024</desc>
+                <code>--machine pentagon1024</code>
+            </value>
+            <value>
+                <id>scorpion</id>
+                <desc>Scorpion ZS 256</desc>
+                <code>--machine scorpion</code>
+            </value>
+            <value>
+                <id>2048</id>
+                <desc>TC2048</desc>
+                <code>--machine 2048</code>
+            </value>
+            <value>
+                <id>2068</id>
+                <desc>TC2068</desc>
+                <code>--machine 2068</code>
+            </value>
+            <value>
+                <id>ts2068</id>
+                <desc>TS2068</desc>
+                <code>--machine ts2068</code>
+            </value>
+        </option>
+
+    </system>
+```
+
+Reference
+=========
+
+Each <option> has the following:
+
+* `id` - a unique ID identifying the option - this is used to save the data
+* `replace` - the text from the command to replace
+* `desc` - a user-friendly description for this option
+* `default` - the ID of the value to be used by default
+* `value` - one per value
+
+Each <value> has the following:
+
+* `id` - a unique ID identifying the value - this is used to save the data
+* `desc` - a user-friendly description for this value
+* `code` - the text which will be put in the command line in the place of the option's `replace`
+

--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -8,6 +8,8 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/PlatformId.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ScraperCmdLine.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemData.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemOption.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemOptionValue.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/VolumeControl.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gamelist.h
 
@@ -57,6 +59,8 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/PlatformId.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ScraperCmdLine.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemData.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemOption.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemOptionValue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/VolumeControl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gamelist.cpp
 

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -142,3 +142,26 @@ void FileData::sort(const SortType& type)
 {
 	sort(*type.comparisonFunction, type.ascending);
 }
+
+
+std::string FileData::getOption( SystemOption* option, bool inheritParents, bool useDefault )
+{
+	std::string value;
+	std::string metaDataID = option->getMetaDataID();
+
+	if( metadata.has( metaDataID ) )
+	{
+		value = metadata.get( metaDataID );
+
+		if( value.size() > 0 )
+			return value;
+	}
+
+	if( inheritParents && mParent != NULL )
+		return mParent->getOption( option, inheritParents, useDefault );
+
+	if( useDefault )
+		return option->getDefaultID();
+
+	return "";
+}

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -6,6 +6,7 @@
 #include "MetaData.h"
 
 class SystemData;
+class SystemOption;
 
 enum FileType
 {
@@ -65,6 +66,8 @@ public:
 
 	void sort(ComparisonFunction& comparator, bool ascending = true);
 	void sort(const SortType& type);
+
+	std::string getOption( SystemOption* option, bool inheritParents, bool useDefault );
 
 	MetaDataList metadata;
 

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -77,6 +77,11 @@ MetaDataList MetaDataList::createFromXML(MetaDataListType type, pugi::xml_node n
 		}
 	}
 
+	// special-case reading the 'options_' entries
+	for (pugi::xml_node child = node.first_child(); child; child = child.next_sibling())
+		if( isOption( child.name() ) )
+			mdl.set( child.name(), child.text().get() );
+
 	return mdl;
 }
 
@@ -102,6 +107,11 @@ void MetaDataList::appendToXML(pugi::xml_node parent, bool ignoreDefaults, const
 			parent.append_child(mapIter->first.c_str()).text().set(value.c_str());
 		}
 	}
+
+	// special-case writing the 'options_' entries
+	for(auto optionIter = mMap.begin(); optionIter != mMap.end(); optionIter++)
+	    if( isOption(optionIter->first.c_str()) && optionIter->second.size() > 0 )
+			parent.append_child(optionIter->first.c_str()).text().set( optionIter->second.c_str() );
 }
 
 void MetaDataList::set(const std::string& key, const std::string& value)
@@ -112,6 +122,11 @@ void MetaDataList::set(const std::string& key, const std::string& value)
 void MetaDataList::setTime(const std::string& key, const boost::posix_time::ptime& time)
 {
 	mMap[key] = boost::posix_time::to_iso_string(time);
+}
+
+const bool MetaDataList::has( const std::string& key ) const
+{
+	return mMap.count( key );
 }
 
 const std::string& MetaDataList::get(const std::string& key) const
@@ -133,3 +148,9 @@ boost::posix_time::ptime MetaDataList::getTime(const std::string& key) const
 {
 	return string_to_ptime(get(key), "%Y%m%dT%H%M%S%F%q");
 }
+
+bool MetaDataList::isOption(const char * key)
+{
+	return strncmp( key, "option_", 7 ) == 0;
+}
+

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -51,6 +51,7 @@ public:
 	void set(const std::string& key, const std::string& value);
 	void setTime(const std::string& key, const boost::posix_time::ptime& time); //times are internally stored as ISO strings (e.g. boost::posix_time::to_iso_string(ptime))
 
+	const bool has( const std::string& key ) const;
 	const std::string& get(const std::string& key) const;
 	int getInt(const std::string& key) const;
 	float getFloat(const std::string& key) const;
@@ -62,4 +63,5 @@ public:
 private:
 	MetaDataListType mType;
 	std::map<std::string, std::string> mMap;
+	static bool isOption(const char * key);
 };

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -7,6 +7,7 @@
 #include "MetaData.h"
 #include "PlatformId.h"
 #include "ThemeData.h"
+#include "SystemOption.h"
 
 class SystemData
 {
@@ -33,7 +34,12 @@ public:
 	
 	unsigned int getGameCount() const;
 
+	std::string replaceOptions( std::string command, FileData* game );
 	void launchGame(Window* window, FileData* game);
+
+	bool hasOptions() const { return mOptions.size() > 0; }
+	const std::vector<SystemOption*>& getOptions() const { return mOptions; }
+	std::string getOption( std::string id, FileData *game );
 
 	static void deleteSystems();
 	static bool loadConfig(); //Load the system config file at getConfigPath(). Returns true if no errors were encountered. An example will be written if the file doesn't exist.
@@ -73,6 +79,7 @@ private:
 	std::vector<PlatformIds::PlatformId> mPlatformIds;
 	std::string mThemeFolder;
 	std::shared_ptr<ThemeData> mTheme;
+	std::vector<SystemOption*> mOptions;
 
 	void populateFolder(FileData* folder);
 

--- a/es-app/src/SystemOption.cpp
+++ b/es-app/src/SystemOption.cpp
@@ -1,0 +1,36 @@
+#include "SystemData.h"
+#include "Gamelist.h"
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <stdlib.h>
+
+SystemOption::SystemOption(const std::string& id, const std::string& replace, const std::string& desc, const std::string& defaultID)
+{
+    mID = id;
+    mMetaDataID = "option_" + id;
+    mReplace = replace;
+    mDesc = desc;
+    mDefaultID = defaultID;
+    mDefault = NULL;
+}
+
+void SystemOption::addValue( SystemOptionValue* value )
+{
+    mValues.push_back( value );
+
+    if( value->getID().compare( mDefaultID ) == 0 )
+        mDefault = value;
+}
+
+SystemOptionValue* SystemOption::getValue( std::string id )
+{
+    for( auto value = mValues.begin(); value != mValues.end(); value++ )
+        if( id.compare( (*value)->getID() ) == 0 )
+            return (*value);
+
+    return NULL;
+}
+
+SystemOption::~SystemOption()
+{
+}

--- a/es-app/src/SystemOption.h
+++ b/es-app/src/SystemOption.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include "FileData.h"
+#include "Window.h"
+#include "MetaData.h"
+#include "PlatformId.h"
+#include "ThemeData.h"
+#include "SystemOptionValue.h"
+
+class SystemOption
+{
+public:
+    SystemOption(const std::string& id, const std::string& replace, const std::string& desc, const std::string& defaultValue);
+    ~SystemOption();
+
+    inline const std::string& getID() const { return mID; }
+    inline const std::string& getMetaDataID() const { return mMetaDataID; }
+    inline const std::string& getReplace() const { return mReplace; }
+    inline const std::string& getDesc() const { return mDesc; }
+    inline const std::string& getDefaultID() const { return mDefaultID; }
+    inline SystemOptionValue* getDefault() const { return mDefault; }
+
+    void addValue( SystemOptionValue* value );
+
+    bool hasValues() const { return mValues.size() > 0; }
+    bool hasDefault() const { return mDefaultID.size() > 0; }
+    const std::vector<SystemOptionValue*>& getValues() const { return mValues; }
+    SystemOptionValue* getValue( std::string id );
+
+//    inline const std::vector<std::string>& getExtensions() const { return mSearchExtensions; }
+
+private:
+    std::string mID;
+    std::string mMetaDataID;
+    std::string mReplace;
+    std::string mDesc;
+    std::string mDefaultID;
+    std::vector<SystemOptionValue*> mValues;
+    SystemOptionValue* mDefault;
+};

--- a/es-app/src/SystemOptionValue.cpp
+++ b/es-app/src/SystemOptionValue.cpp
@@ -1,0 +1,16 @@
+#include "SystemData.h"
+#include "Gamelist.h"
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <stdlib.h>
+
+SystemOptionValue::SystemOptionValue(const std::string& id, const std::string& desc, const std::string& code)
+{
+    mID = id;
+    mDesc = desc;
+    mCode = code;
+}
+
+SystemOptionValue::~SystemOptionValue()
+{
+}

--- a/es-app/src/SystemOptionValue.h
+++ b/es-app/src/SystemOptionValue.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include "FileData.h"
+#include "Window.h"
+#include "MetaData.h"
+#include "PlatformId.h"
+#include "ThemeData.h"
+
+class SystemOptionValue
+{
+public:
+    SystemOptionValue(const std::string& id, const std::string& desc, const std::string& code);
+    ~SystemOptionValue();
+
+    inline const std::string& getID() const { return mID; }
+    inline const std::string& getDesc() const { return mDesc; }
+    inline const std::string& getCode() const { return mCode; }
+
+private:
+    std::string mID;
+    std::string mDesc;
+    std::string mCode;
+};

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -2,6 +2,7 @@
 #include "components/MenuComponent.h"
 #include "components/OptionListComponent.h"
 #include "FileSorts.h"
+#include "SystemOption.h"
 
 class IGameListView;
 
@@ -28,4 +29,6 @@ private:
 	
 	SystemData* mSystem;
 	IGameListView* getGamelist();
+
+	std::map< SystemOption*, std::shared_ptr<OptionListComponent<SystemOptionValue*> > > mOptions;
 };

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -43,7 +43,10 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 
 	for(auto it = files.begin(); it != files.end(); it++)
 	{
-		mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));
+		if((*it)->getType() == FOLDER )
+			mList.add( (*it)->getName() + " >", *it, true );
+		else
+			mList.add( (*it)->getName(), *it, false );
 	}
 }
 


### PR DESCRIPTION
At the moment this approach saves additional metadata to gamelist.xml - there are some special cases in MetaData.cpp to deal with this.  The options get saved in the metadata as entries prefixed with "option_", so other tools shouldn't have a problem with them.

The only issue here is if any external tools completely re-write gamelist.xml and lose the options - perhaps we should consider saving these options in a seperate file?

It may be worth (in the future) considering a other ways of saving the metadata, perhaps in a file-per-game? (e.g. a game MyGame.tzx would have an associated MyGame.tzx.meta) - this would have the added advantage of making it 'easier' to copy files around retaining their metadata.
