### PR TITLE
Fix for SDL window being bigger than screen in windows.

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -62,6 +62,10 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 		}else if(strcmp(argv[i], "--windowed") == 0)
 		{
 			Settings::getInstance()->setBool("Windowed", true);
+		}
+		else if (strcmp(argv[i], "--force-desktop-resolution") == 0)
+		{
+			Settings::getInstance()->setBool("ForceDesktopResolution", true);
 		}else if(strcmp(argv[i], "--vsync") == 0)
 		{
 			bool vsync = (strcmp(argv[i + 1], "on") == 0 || strcmp(argv[i + 1], "1") == 0) ? true : false;
@@ -83,6 +87,7 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 				"Version " << PROGRAM_VERSION_STRING << ", built " << PROGRAM_BUILT_STRING << "\n\n"
 				"Command line arguments:\n"
 				"--resolution [width] [height]	try and force a particular resolution\n"
+				"--force-desktop-resolution	force the use of desktop resolution in fullscreen mode\n"
 				"--gamelist-only			skip automatic game search, only read from gamelist.xml\n"
 				"--ignore-gamelist		ignore the gamelist (useful for troubleshooting)\n"
 				"--draw-framerate		display the framerate\n"

--- a/es-core/src/Renderer_init_sdlgl.cpp
+++ b/es-core/src/Renderer_init_sdlgl.cpp
@@ -57,10 +57,13 @@ namespace Renderer
 		if(display_height == 0)
 			display_height = dispMode.h;
 
+		// Forcing SDL_WINDOW_FULLSCREEN_DESKTOP seems to fix res issues in windows.
+		Uint32 windowFullscreenMode = (Settings::getInstance()->getBool("ForceDesktopResolution") ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN);
+
 		sdlWindow = SDL_CreateWindow("EmulationStation", 
 			SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 
 			display_width, display_height, 
-			SDL_WINDOW_OPENGL | (Settings::getInstance()->getBool("Windowed") ? 0 : SDL_WINDOW_FULLSCREEN));
+			SDL_WINDOW_OPENGL | (Settings::getInstance()->getBool("Windowed") ? 0 : windowFullscreenMode));
 
 		if(sdlWindow == NULL)
 		{


### PR DESCRIPTION
Seems some users (myself included) are having some issues with parts of the window being cut off under fullscreen in windows. This option is a workaround for the issue, I can't work out why the issue exists at all.