### PR TITLE
Working on Mac OS X Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
 project(emulationstation-all)
 
 #-------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 project(emulationstation-all)
 
 #-------------------------------------------------------------------------------

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -191,7 +191,7 @@ void SystemData::populateFolder(FileData* folder)
         //on a filesystem (e.g. network share) which does not have native support for HFS+ metadata.
         //
         //In that situation, OS X puts ._SomeFile clutter all over the place.
-         
+        
         std::string prefix = ".";
         
 		isGame = false;
@@ -203,11 +203,6 @@ void SystemData::populateFolder(FileData* folder)
 			isGame = true;
 		}
         
-
-        if (filePath.filename().string().compare(0, prefix.length(), prefix) == 0) {
-            std::cout << filePath.filename().string();
-            isGame = false;
-        }
 
 		//add directories that also do not match an extension as folders
 		if(!isGame && fs::is_directory(filePath))

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -185,13 +185,29 @@ void SystemData::populateFolder(FileData* folder)
 		//fyi, folders *can* also match the extension and be added as games - this is mostly just to support higan
 		//see issue #75: https://github.com/Aloshi/EmulationStation/issues/75
 
+        //We'll ignore any filenames starting with a period.
+        //
+        //Generally a good idea on unix-ish systems, but especially important on OS X when files are stored
+        //on a filesystem (e.g. network share) which does not have native support for HFS+ metadata.
+        //
+        //In that situation, OS X puts ._SomeFile clutter all over the place.
+         
+        std::string prefix = ".";
+        
 		isGame = false;
-		if(std::find(mSearchExtensions.begin(), mSearchExtensions.end(), extension) != mSearchExtensions.end())
+		if(std::find(mSearchExtensions.begin(), mSearchExtensions.end(), extension) != mSearchExtensions.end() &&
+           filePath.filename().string().compare(0, prefix.length(), prefix) != 0)
 		{
 			FileData* newGame = new FileData(GAME, filePath.generic_string(), this);
 			folder->addChild(newGame);
 			isGame = true;
 		}
+        
+
+        if (filePath.filename().string().compare(0, prefix.length(), prefix) == 0) {
+            std::cout << filePath.filename().string();
+            isGame = false;
+        }
 
 		//add directories that also do not match an extension as folders
 		if(!isGame && fs::is_directory(filePath))

--- a/es-app/src/VolumeControl.cpp
+++ b/es-app/src/VolumeControl.cpp
@@ -18,7 +18,7 @@ std::weak_ptr<VolumeControl> VolumeControl::sInstance;
 VolumeControl::VolumeControl()
 	: originalVolume(0), internalVolume(0)
 #if defined (__APPLE__)
-    #error TODO: Not implemented for MacOS yet!!!
+
 #elif defined(__linux__)
     , mixerIndex(0), mixerHandle(nullptr), mixerElem(nullptr), mixerSelemId(nullptr)
 #elif defined(WIN32) || defined(_WIN32)
@@ -68,7 +68,7 @@ void VolumeControl::init()
 {
 	//initialize audio mixer interface
 #if defined (__APPLE__)
-	#error TODO: Not implemented for MacOS yet!!!
+    
 #elif defined(__linux__)
 	//try to open mixer device
 	if (mixerHandle == nullptr)
@@ -212,7 +212,7 @@ void VolumeControl::deinit()
 {
 	//deinitialize audio mixer interface
 #if defined (__APPLE__)
-	#error TODO: Not implemented for MacOS yet!!!
+    
 #elif defined(__linux__)
 	if (mixerHandle != nullptr) {
 		snd_mixer_detach(mixerHandle, mixerCard);
@@ -239,7 +239,7 @@ int VolumeControl::getVolume() const
 	int volume = 0;
 
 #if defined (__APPLE__)
-    #error TODO: Not implemented for MacOS yet!!!
+    return 0;
 #elif defined(__linux__)
 	if (mixerElem != nullptr)
 	{
@@ -333,7 +333,7 @@ void VolumeControl::setVolume(int volume)
 	//store values in internal variables
 	internalVolume = volume;
 #if defined (__APPLE__)
-    #error TODO: Not implemented for MacOS yet!!!
+    return;
 #elif defined(__linux__)
 	if (mixerElem != nullptr)
 	{

--- a/es-app/src/VolumeControl.h
+++ b/es-app/src/VolumeControl.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #if defined (__APPLE__)
-    #error TODO: Not implemented for MacOS yet!!!
+
 #elif defined(__linux__)
 	#include <unistd.h>
 	#include <fcntl.h>
@@ -22,7 +22,7 @@ Singleton pattern. Call getInstance() to get an object.
 class VolumeControl
 {
 #if defined (__APPLE__)
-    #error TODO: Not implemented for MacOS yet!!!
+
 #elif defined(__linux__)
     static const char * mixerName;
     static const char * mixerCard;

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -31,8 +31,10 @@ protected:
 	using IList<TextListData, T>::getTransform;
 	using IList<TextListData, T>::mSize;
 	using IList<TextListData, T>::mCursor;
+#ifndef __APPLE__
 	using IList<TextListData, T>::Entry;
-
+#endif
+    
 public:
 	using IList<TextListData, T>::size;
 	using IList<TextListData, T>::isScrolling;

--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -3,7 +3,7 @@
 #include <SDL.h>
 #include "Log.h"
 
-std::vector<std::shared_ptr<Sound>> AudioManager::sSoundVector;
+std::vector<std::shared_ptr<Sound> > AudioManager::sSoundVector;
 SDL_AudioSpec AudioManager::sAudioFormat;
 std::shared_ptr<AudioManager> AudioManager::sInstance;
 
@@ -16,7 +16,7 @@ void AudioManager::mixAudio(void *unused, Uint8 *stream, int len)
 	SDL_memset(stream, 0, len);
 
 	//iterate through all our samples
-	std::vector<std::shared_ptr<Sound>>::const_iterator soundIt = sSoundVector.cbegin();
+	std::vector<std::shared_ptr<Sound> >::const_iterator soundIt = sSoundVector.cbegin();
 	while (soundIt != sSoundVector.cend())
 	{
 		std::shared_ptr<Sound> sound = *soundIt;

--- a/es-core/src/AudioManager.h
+++ b/es-core/src/AudioManager.h
@@ -12,7 +12,7 @@
 class AudioManager
 {
 	static SDL_AudioSpec sAudioFormat;
-	static std::vector<std::shared_ptr<Sound>> sSoundVector;
+	static std::vector<std::shared_ptr<Sound> > sSoundVector;
 	static std::shared_ptr<AudioManager> sInstance;
 
 	static void mixAudio(void *unused, Uint8 *stream, int len);

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -11,9 +11,18 @@
 Window::Window() : mNormalizeNextUpdate(false), mFrameTimeElapsed(0), mFrameCountElapsed(0), mAverageDeltaTime(10), 
 	mAllowSleep(true), mSleeping(false), mTimeSinceLastInput(0)
 {
+    
 	mHelp = new HelpComponent(this);
 	mBackgroundOverlay = new ImageComponent(this);
-	mBackgroundOverlay->setImage(":/scroll_gradient.png");
+	
+    
+#ifndef __APPLE__
+    // This ends up calling some OpenGL methods before SDL has been asked to create a context
+    // On Mac OS X at least, this causes a EXC_BAD_ACCESS (segfault)
+    mBackgroundOverlay->setImage(":/scroll_gradient.png");
+#endif
+    
+
 }
 
 Window::~Window()
@@ -59,6 +68,9 @@ GuiComponent* Window::peekGui()
 
 bool Window::init(unsigned int width, unsigned int height)
 {
+    
+  
+
 	if(!Renderer::init(width, height))
 	{
 		LOG(LogError) << "Renderer failed to initialize!";
@@ -69,6 +81,7 @@ bool Window::init(unsigned int width, unsigned int height)
 
 	ResourceManager::getInstance()->reloadAll();
 
+    
 	//keep a reference to the default fonts, so they don't keep getting destroyed/recreated
 	if(mDefaultFonts.empty())
 	{

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -21,8 +21,10 @@ protected:
 	using IList<ImageGridData, T>::getTransform;
 	using IList<ImageGridData, T>::mSize;
 	using IList<ImageGridData, T>::mCursor;
-	using IList<ImageGridData, T>::Entry;
-	using IList<ImageGridData, T>::mWindow;
+#ifndef __APPLE__
+    using IList<ImageGridData, T>::Entry;
+#endif
+    using IList<ImageGridData, T>::mWindow;
 
 public:
 	using IList<ImageGridData, T>::size;


### PR DESCRIPTION
Hi,

This project looked very cool indeed and I'd like to get it working on my Mac Mini HTPC.  

I followed the standard instructions to build.  Initially I had to satisfy a couple of dependencies using the OS X 'Homebrew' package manager.  I also downloaded the latest SDL Framework for OS X and copied it to /Library/Frameworks as normal.  

So, then it at least started compiling.  However, I had to make a couple of changes to the source tree to get things up and running.

The main sticking-point is that I've merely left the methods in VolumeControl.cpp as 'no-ops' rather than #errors for when __APPLE__ is defined.  I'll come to that later when I learn how to use the CoreAudio framework in C++.

I had to make a few changes to cmake's settings to get it to build with clang on OS X.  

Anyway, EmulationStation now launches on my Mac.  I just need to configure it and test it to see how much of it actually works as expected.  Thought I'd send this PR over since it might at least act as a basis for further Mac support.
