### PR TITLE
Sorting and MSVC 2015 fixes

### DIFF
--- a/es-app/src/FileSorts.cpp
+++ b/es-app/src/FileSorts.cpp
@@ -42,10 +42,12 @@ namespace FileSorts
 		//only games have rating metadata
 		if(file1->metadata.getType() == GAME_METADATA && file2->metadata.getType() == GAME_METADATA)
 		{
-			return file1->metadata.getFloat("rating") < file2->metadata.getFloat("rating");
+			float r1 = file1->metadata.getFloat("rating"), r2 = file2->metadata.getFloat("rating");
+			if (r1 != r2)
+				return r1 < r2;
 		}
 
-		return false;
+		return compareFileName(file1, file2);
 	}
 
 	bool compareTimesPlayed(const FileData* file1, const FileData* file2)
@@ -53,10 +55,12 @@ namespace FileSorts
 		//only games have playcount metadata
 		if(file1->metadata.getType() == GAME_METADATA && file2->metadata.getType() == GAME_METADATA)
 		{
-			return (file1)->metadata.getInt("playcount") < (file2)->metadata.getInt("playcount");
+			int pc1 = (file1)->metadata.getInt("playcount"), pc2 = (file2)->metadata.getInt("playcount");
+			if(pc1 != pc2)
+				return pc1 < pc2;
 		}
 
-		return false;
+		return compareFileName(file1, file2);
 	}
 
 	bool compareLastPlayed(const FileData* file1, const FileData* file2)

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -102,6 +102,9 @@ void parseGamelist(SystemData* system)
 		return;
 	}
 
+	/* Set system sort ID */
+	system->sortId = root.attribute("sortid").as_int(0);
+
 	fs::path relativeTo = system->getStartPath();
 
 	const char* tagList[2] = { "game", "folder" };
@@ -197,6 +200,9 @@ void updateGamelist(SystemData* system)
 		root = doc.append_child("gameList");
 	}
 
+	// Update to the current sort type for this system
+	root.remove_attribute("sortid");
+	root.append_attribute("sortid") = std::to_string(system->sortId).c_str();
 
 	//now we have all the information from the XML. now iterate through all our games and add information from there
 	FileData* rootFolder = system->getRootFolder();

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -23,6 +23,7 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, con
 	mName = name;
 	mFullName = fullName;
 	mStartPath = startPath;
+	sortId = 0; /* This may be updated before sorting by stored gamelist data */
 
 	//expand home symbol if the startpath contains ~
 	if(mStartPath[0] == '~')
@@ -45,7 +46,7 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, con
 	if(!Settings::getInstance()->getBool("IgnoreGamelist"))
 		parseGamelist(this);
 
-	mRootFolder->sort(FileSorts::SortTypes.at(0));
+	mRootFolder->sort(FileSorts::SortTypes.at(sortId));
 
 	loadTheme();
 }
@@ -60,7 +61,6 @@ SystemData::~SystemData()
 
 	delete mRootFolder;
 }
-
 
 std::string strreplace(std::string str, const std::string& replace, const std::string& with)
 {
@@ -308,7 +308,7 @@ bool SystemData::loadConfig()
 			continue;
 		}
 
-		//convert path to generic directory seperators
+		//convert path to generic directory separators
 		boost::filesystem::path genericPath(path);
 		path = genericPath.generic_string();
 

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -64,6 +64,8 @@ public:
 	// Load or re-load theme.
 	void loadTheme();
 
+	unsigned int sortId;
+
 private:
 	std::string mName;
 	std::string mFullName;

--- a/es-app/src/guis/GuiFastSelect.cpp
+++ b/es-app/src/guis/GuiFastSelect.cpp
@@ -132,7 +132,11 @@ void GuiFastSelect::updateGameListSort()
 {
 	const FileData::SortType& sort = FileSorts::SortTypes.at(mSortId);
 
-	FileData* root = mGameList->getCursor()->getSystem()->getRootFolder();
+	SystemData* system = mGameList->getCursor()->getSystem();
+	FileData* root = system->getRootFolder();
+
+	system->sortId = mSortId; // update system sort setting
+
 	root->sort(sort); // will also recursively sort children
 
 	// notify that the root folder was sorted

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -40,7 +40,7 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	for(unsigned int i = 0; i < FileSorts::SortTypes.size(); i++)
 	{
 		const FileData::SortType& sort = FileSorts::SortTypes.at(i);
-		mListSort->add(sort.description, &sort, i == 0); // TODO - actually make the sort type persistent
+		mListSort->add(sort.description, &sort, i == system->sortId);
 	}
 
 	mMenu.addWithLabel("SORT GAMES BY", mListSort);
@@ -59,8 +59,10 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 
 GuiGamelistOptions::~GuiGamelistOptions()
 {
-	// apply sort
-	FileData* root = getGamelist()->getCursor()->getSystem()->getRootFolder();
+	// save and apply sort
+	SystemData* system = getGamelist()->getCursor()->getSystem();
+	FileData* root = system->getRootFolder();
+	system->sortId = mListSort->getSelectedId(); // this will break if mListSort isn't in the same order as FileSorts:typesArr
 	root->sort(*mListSort->getSelected()); // will also recursively sort children
 
 	// notify that the root folder was sorted

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -22,6 +22,7 @@
 
 #ifdef WIN32
 #include <Windows.h>
+#include <shellapi.h>
 #endif
 
 namespace fs = boost::filesystem;
@@ -338,3 +339,26 @@ int main(int argc, char* argv[])
 
 	return 0;
 }
+
+#ifdef WIN32
+int CALLBACK WinMain(
+	_In_ HINSTANCE hInstance,
+	_In_ HINSTANCE hPrevInstance,
+	_In_ LPSTR     lpCmdLine,
+	_In_ int       nCmdShow
+	)
+{
+	/* Just convert command-line arguments to UTF-8 and call main() */
+	int argc, i;
+	LPWSTR *argvW = CommandLineToArgvW(GetCommandLineW(), &argc);
+	char **argv = new char *[argc];
+	for (i = 0; i < argc; i++)
+	{
+		int len = WideCharToMultiByte(CP_UTF8, 0, argvW[i], -1, NULL, 0, NULL, NULL);
+		argv[i] = new char[len];
+		WideCharToMultiByte(CP_UTF8, 0, argvW[i], -1, argv[i], len, NULL, NULL);
+	}
+	main(argc, argv);
+}
+
+#endif /* WIN32 */

--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -33,6 +33,14 @@ float round(float num)
 }
 #endif
 
+#if _MSC_VER >= 1700
+FILE iob[] = {*stdin, *stdout, *stderr };
+FILE * __iob_func(void)
+{
+	return iob;
+}
+#endif
+
 Eigen::Affine3f& roundMatrix(Eigen::Affine3f& mat)
 {
 	mat.translation()[0] = round(mat.translation()[0]);

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -15,7 +15,9 @@ Eigen::Affine3f roundMatrix(const Eigen::Affine3f& mat);
 Eigen::Vector3f roundVector(const Eigen::Vector3f& vec);
 Eigen::Vector2f roundVector(const Eigen::Vector2f& vec);
 
+#if _MSC_VER < 1800
 float round(float num);
+#endif /* _MSC_VER */
 
 std::string getCanonicalPath(const std::string& str);
 

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -251,7 +251,6 @@ public:
 		onSelectedChanged();
 	}
 
-private:
 	unsigned int getSelectedId()
 	{
 		assert(mMultiSelect == false);
@@ -265,6 +264,7 @@ private:
 		return 0;
 	}
 
+private:
 	void open()
 	{
 		mWindow->pushGui(new OptionListPopup(mWindow, this, mName));


### PR DESCRIPTION
I've got three commits in this pull request:

* 276a207: when sorting by rating or playcount, if two files are tied, break the tie with compareFileName
* 5748744: Get the project compiling in MSVC 2015 Community (I'm not sure whether these were all necessary or if I could've gotten around them)
** Add WinMain when compiling in MSVC
** Define __iob_func for compatibility with older DLLs
** Wrap the declaration of round() in the same preprocessor check as its implementation
* ce00f5f: Make the sort type persistent by storing the sort ID in a new gamelist attribute ("sortid")

How do they look?

Thanks,

 -- Adam Slater