### PR TITLE
Add a sort option for the scrapped name

### DIFF
--- a/es-app/src/FileSorts.cpp
+++ b/es-app/src/FileSorts.cpp
@@ -6,6 +6,9 @@ namespace FileSorts
 		FileData::SortType(&compareFileName, true, "filename, ascending"),
 		FileData::SortType(&compareFileName, false, "filename, descending"),
 
+		FileData::SortType(&compareName, true, "name, ascending"),
+		FileData::SortType(&compareName, false, "name, descending"),
+
 		FileData::SortType(&compareRating, true, "rating, ascending"),
 		FileData::SortType(&compareRating, false, "rating, descending"),
 
@@ -65,6 +68,17 @@ namespace FileSorts
 		if(file1->metadata.getType() == GAME_METADATA && file2->metadata.getType() == GAME_METADATA)
 		{
 			return (file1)->metadata.getTime("lastplayed") < (file2)->metadata.getTime("lastplayed");
+		}
+
+		return false;
+	}
+
+	bool compareName(const FileData* file1, const FileData* file2)
+	{
+		//only games have name metadata
+		if(file1->metadata.getType() == GAME_METADATA && file2->metadata.getType() == GAME_METADATA)
+		{
+			return (file1)->metadata.get("name") < (file2)->metadata.get("name");
 		}
 
 		return false;

--- a/es-app/src/FileSorts.h
+++ b/es-app/src/FileSorts.h
@@ -9,6 +9,7 @@ namespace FileSorts
 	bool compareRating(const FileData* file1, const FileData* file2);
 	bool compareTimesPlayed(const FileData* file1, const FileData* fil2);
 	bool compareLastPlayed(const FileData* file1, const FileData* file2);
+	bool compareName(const FileData* file1, const FileData* file2);
 
 	extern const std::vector<FileData::SortType> SortTypes;
 };


### PR DESCRIPTION
In the menu option for sorting game lists, you can currently sort by filename but not by the scraped name. This small change adds that option.

<img src="http://cloud.mattnohr.com/image/3u0k320W1j02/emulation-sort.png" width="400px" />