### PR TITLE
Dynamic system availabilty depending on controler plugged

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -24,6 +24,7 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, con
 	mFullName = fullName;
 	mStartPath = startPath;
         mInput = input;
+        updateVisibility();
 
 	//expand home symbol if the startpath contains ~
 	if(mStartPath[0] == '~')
@@ -49,6 +50,11 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, con
 	mRootFolder->sort(FileSorts::SortTypes.at(0));
 
 	loadTheme();
+}
+
+void SystemData::updateVisibility()
+{
+	mVisible = InputManager::getInstance()->isInputFound(mInput);
 }
 
 SystemData::~SystemData()

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -111,6 +111,15 @@ std::string escapePath(const boost::filesystem::path& path)
 #endif
 }
 
+void SystemData::updateSystems()
+{
+	for(unsigned int i = 0; i < sSystemVector.size(); i++)
+	{
+                SystemData *v = sSystemVector.at(i);
+		v->updateVisibility();
+	}
+}
+
 void SystemData::launchGame(Window* window, FileData* game)
 {
 	LOG(LogInfo) << "Attempting to launch game...";

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -17,12 +17,13 @@ std::vector<SystemData*> SystemData::sSystemVector;
 
 namespace fs = boost::filesystem;
 
-SystemData::SystemData(const std::string& name, const std::string& fullName, const std::string& startPath, const std::vector<std::string>& extensions, 
+SystemData::SystemData(const std::string& name, const std::string& fullName, const std::string& input, const std::string& startPath, const std::vector<std::string>& extensions, 
 	const std::string& command, const std::vector<PlatformIds::PlatformId>& platformIds, const std::string& themeFolder)
 {
 	mName = name;
 	mFullName = fullName;
 	mStartPath = startPath;
+        mInput = input;
 
 	//expand home symbol if the startpath contains ~
 	if(mStartPath[0] == '~')
@@ -262,12 +263,13 @@ bool SystemData::loadConfig()
 
 	for(pugi::xml_node system = systemList.child("system"); system; system = system.next_sibling("system"))
 	{
-		std::string name, fullname, path, cmd, themeFolder;
+		std::string name, fullname, path, cmd, themeFolder, input;
 		PlatformIds::PlatformId platformId = PlatformIds::PLATFORM_UNKNOWN;
 
 		name = system.child("name").text().get();
 		fullname = system.child("fullname").text().get();
 		path = system.child("path").text().get();
+                input = system.child("input").text().get();
 
 		// convert extensions list from a string into a vector of strings
 		std::vector<std::string> extensions = readList(system.child("extension").text().get());
@@ -312,7 +314,7 @@ bool SystemData::loadConfig()
 		boost::filesystem::path genericPath(path);
 		path = genericPath.generic_string();
 
-		SystemData* newSys = new SystemData(name, fullname, path, extensions, cmd, platformIds, themeFolder);
+		SystemData* newSys = new SystemData(name, fullname, input, path, extensions, cmd, platformIds, themeFolder);
 		if(newSys->getRootFolder()->getChildren().size() == 0)
 		{
 			LOG(LogWarning) << "System \"" << name << "\" has no games! Ignoring it.";

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -11,13 +11,14 @@
 class SystemData
 {
 public:
-	SystemData(const std::string& name, const std::string& fullName, const std::string& startPath, const std::vector<std::string>& extensions, 
+	SystemData(const std::string& name, const std::string& fullName, const std::string& input, const std::string& startPath, const std::vector<std::string>& extensions, 
 		const std::string& command, const std::vector<PlatformIds::PlatformId>& platformIds, const std::string& themeFolder);
 	~SystemData();
 
 	inline FileData* getRootFolder() const { return mRootFolder; };
 	inline const std::string& getName() const { return mName; }
 	inline const std::string& getFullName() const { return mFullName; }
+        inline const std::string& getInput() const { return mInput; }
 	inline const std::string& getStartPath() const { return mStartPath; }
 	inline const std::vector<std::string>& getExtensions() const { return mSearchExtensions; }
 	inline const std::string& getThemeFolder() const { return mThemeFolder; }
@@ -68,6 +69,7 @@ private:
 	std::string mName;
 	std::string mFullName;
 	std::string mStartPath;
+        std::string mInput;
 	std::vector<std::string> mSearchExtensions;
 	std::string mLaunchCommand;
 	std::vector<PlatformIds::PlatformId> mPlatformIds;

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -18,6 +18,7 @@ public:
 	inline FileData* getRootFolder() const { return mRootFolder; };
 	inline const std::string& getName() const { return mName; }
 	inline const std::string& getFullName() const { return mFullName; }
+        inline const bool& isVisible() const { return mVisible; }
         inline const std::string& getInput() const { return mInput; }
 	inline const std::string& getStartPath() const { return mStartPath; }
 	inline const std::vector<std::string>& getExtensions() const { return mSearchExtensions; }
@@ -64,6 +65,7 @@ public:
 
 	// Load or re-load theme.
 	void loadTheme();
+        void updateVisibility();
 
 private:
 	std::string mName;
@@ -75,6 +77,8 @@ private:
 	std::vector<PlatformIds::PlatformId> mPlatformIds;
 	std::string mThemeFolder;
 	std::shared_ptr<ThemeData> mTheme;
+
+        bool mVisible;
 
 	void populateFolder(FileData* folder);
 

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -67,6 +67,8 @@ public:
 	void loadTheme();
         void updateVisibility();
 
+        static void updateSystems();
+
 private:
 	std::string mName;
 	std::string mFullName;

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -304,6 +304,16 @@ int main(int argc, char* argv[])
 					running = false;
 					break;
 			}
+			switch(event.type)
+			{
+				case SDL_JOYDEVICEADDED:
+				case SDL_JOYDEVICEREMOVED:
+					SystemData::updateSystems();
+					ViewController::get()->reloadAll();
+					break;
+				default:
+					break;
+			}
 		}
 
 		if(window.isSleeping())

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -34,6 +34,7 @@ void SystemView::populate()
 
 	for(auto it = SystemData::sSystemVector.begin(); it != SystemData::sSystemVector.end(); it++)
 	{
+                if (!(*it)->isVisible()) continue;
 		const std::shared_ptr<ThemeData>& theme = (*it)->getTheme();
 
 		Entry e;

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -62,6 +62,19 @@ void InputManager::init()
 	loadInputConfig(mKeyboardInputConfig);
 }
 
+bool InputManager::isInputFound(const std::string& name) {
+	if (name.empty()) return true;
+	int numJoysticks = SDL_NumJoysticks();
+	for(int i = 0; i < numJoysticks; i++)
+	{
+                std::string s(SDL_JoystickNameForIndex(i));
+		if (s.find(name, 0) != std::string::npos) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void InputManager::addJoystickByDeviceIndex(int id)
 {
 	assert(id >= 0 && id < SDL_NumJoysticks());

--- a/es-core/src/InputManager.h
+++ b/es-core/src/InputManager.h
@@ -53,6 +53,8 @@ public:
 	InputConfig* getInputConfigByDevice(int deviceId);
 
 	bool parseEvent(const SDL_Event& ev, Window* window);
+
+	bool isInputFound(const std::string& name);
 };
 
 #endif


### PR DESCRIPTION
Hi,

First thanks for this frontend. Its is really nice and working well with my arcade machine.

I add an issue regarding input Controler and some systems.  I have an arcade machine with a Xin-Mo module. I also add the support of a PS3 Blurtooth controller. Some systems, for example Dreamcast systems have to use the PS3 controller only (There is a need for anlaog input).

So I modified the emulationstation in order to detect and display system only if the input tag has been setup in the es-systems.cfg file. If the input field is not defined, then the system is always available.

I think other people might want to have such kind of behavior.

Francois







