### PR TITLE
Initialize previous axis values from current values

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -89,7 +89,9 @@ void InputManager::addJoystickByDeviceIndex(int id)
 	// set up the prevAxisValues
 	int numAxes = SDL_JoystickNumAxes(joy);
 	mPrevAxisValues[joyId] = new int[numAxes];
-	std::fill(mPrevAxisValues[joyId], mPrevAxisValues[joyId] + numAxes, 0); //initialize array to 0
+	for(int i = 0; i<numAxes; i++) {
+		mPrevAxisValues[joyId][i] = SDL_JoystickGetAxis(joy, i);
+	}
 }
 
 void InputManager::removeJoystickByJoystickID(SDL_JoystickID joyId)


### PR DESCRIPTION
Instead of using zeros, use the current axis values. This prevents
unwanted scrolling when there are non-centered axis on additional
joysticks on the system.
