### PR TITLE
Add better debug statement for utf8 parsing error

### DIFF
--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -124,7 +124,7 @@ UnicodeChar Font::readUnicodeChar(const std::string& str, size_t& cursor)
 	else
 	{
 		// error, invalid utf8 string
-
+		LOG(LogError) << "Error invalid utf8 string when parsing file: " << str.c_str();
 		// if this assert is tripped, the cursor is in the middle of a utf8 code point
 		assert((c & 0xC0) != 0x80); // character is 10xxxxxx
 


### PR DESCRIPTION
If someone has a lot of roms in a folder and one of the names is invalid, this will print the error to the log before failing on the assert that way they no which file is causing the problem.