### PR TITLE
Add support to built-in thegamesdb.net scraper for TurboGrafx CD platform.

### DIFF
--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -59,6 +59,7 @@ namespace PlatformIds
 		"psp", // playstation portable
 		"snes", // super nintendo entertainment system
 		"pcengine", // turbografx-16/pcengine
+		"pcenginecd", // turbografx-16/pcengine CD-ROM
 		"wonderswan",
 		"wonderswancolor",
 		"zxspectrum",

--- a/es-app/src/PlatformId.h
+++ b/es-app/src/PlatformId.h
@@ -58,7 +58,8 @@ namespace PlatformIds
 		PLAYSTATION_VITA,
 		PLAYSTATION_PORTABLE,
 		SUPER_NINTENDO,
-		TURBOGRAFX_16, // (also PC Engine)
+		TURBOGRAFX_16, // (also PC Engine) hucards only
+		TURBOGRAFX_CD, // (also PC Engine) CD-ROM only
 		WONDERSWAN,
 		WONDERSWAN_COLOR,
 		ZX_SPECTRUM,

--- a/es-app/src/scrapers/GamesDBScraper.cpp
+++ b/es-app/src/scrapers/GamesDBScraper.cpp
@@ -59,6 +59,7 @@ const std::map<PlatformId, const char*> gamesdb_platformid_map = boost::assign::
 	(PLAYSTATION_PORTABLE, "Sony PSP")
 	(SUPER_NINTENDO, "Super Nintendo (SNES)")
 	(TURBOGRAFX_16, "TurboGrafx 16")
+	(TURBOGRAFX_CD, "TurboGrafx CD")
 	(WONDERSWAN, "WonderSwan")
 	(WONDERSWAN_COLOR, "WonderSwan Color")
 	(ZX_SPECTRUM, "Sinclair ZX Spectrum");


### PR DESCRIPTION
This goes partway toward solving https://github.com/Aloshi/EmulationStation/issues/781 by at least providing a way to exclusively scrape TurboGrafx CD games by setting the <platform> node in the config file to "pcenginecd".