### PR TITLE
Disable controller input during startup

### DIFF
--- a/es-app/src/scrapers/GamesDBScraper.cpp
+++ b/es-app/src/scrapers/GamesDBScraper.cpp
@@ -67,7 +67,7 @@ const std::map<PlatformId, const char*> gamesdb_platformid_map = boost::assign::
 void thegamesdb_generate_scraper_requests(const ScraperSearchParams& params, std::queue< std::unique_ptr<ScraperRequest> >& requests, 
 	std::vector<ScraperSearchResult>& results)
 {
-	std::string path = "thegamesdb.net/api/GetGame.php?";
+	std::string path = "legacy.thegamesdb.net/api/GetGame.php?";
 
 	std::string cleanName = params.nameOverride;
 	if(cleanName.empty())

--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -26,7 +26,7 @@ std::string strToUpper(const std::string& str)
 }
 
 
-#if _MSC_VER < 1800
+#if defined(_WIN32) && _MSC_VER < 1800
 float round(float num)
 {
 	return (float)((int)(num + 0.5f));

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -15,7 +15,9 @@ Eigen::Affine3f roundMatrix(const Eigen::Affine3f& mat);
 Eigen::Vector3f roundVector(const Eigen::Vector3f& vec);
 Eigen::Vector2f roundVector(const Eigen::Vector2f& vec);
 
+#if defined(_WIN32) && _MSC_VER < 1800
 float round(float num);
+#endif
 
 std::string getCanonicalPath(const std::string& str);
 


### PR DESCRIPTION
Is it possible to disable controller input during emulationstation startup? I ve seen that while loading all the input are recorded and reflected in the menu when emulationstation is loaded. This potentially could be a problem.